### PR TITLE
The fallible u32->I conversion now implements TryFrom instead of From

### DIFF
--- a/asm_riscv/src/lib.rs
+++ b/asm_riscv/src/lib.rs
@@ -525,91 +525,91 @@ impl TryFrom<u32> for I {
     // Using match makes it easier to extend code in the future.
     #[allow(clippy::match_single_binding)]
     fn try_from(with: u32) -> Result<Self, Self::Error> {
-        match with & 0b1111111 {
+        Ok(match with & 0b1111111 {
             // Load From RAM
             0b0000011 => match I::from_i(with) {
-                (d, 0b000, s, im) => Ok(LB { d, s, im }),
-                (d, 0b001, s, im) => Ok(LH { d, s, im }),
-                (d, 0b010, s, im) => Ok(LW { d, s, im }),
-                (d, 0b100, s, im) => Ok(LBU { d, s, im }),
-                (d, 0b101, s, im) => Ok(LHU { d, s, im }),
-                (_, _, _, _mm) => Err(()),
+                (d, 0b000, s, im) => LB { d, s, im },
+                (d, 0b001, s, im) => LH { d, s, im },
+                (d, 0b010, s, im) => LW { d, s, im },
+                (d, 0b100, s, im) => LBU { d, s, im },
+                (d, 0b101, s, im) => LHU { d, s, im },
+                (_, _, _, _mm) => return Err(()),
             },
             // Misc. Memory Instructions
             0b0001111 => match I::from_i(with) {
-                (_, 0b000, _, im) => Ok(FENCE { im }),
-                (_, _, _, _mm) => Err(()),
+                (_, 0b000, _, im) => FENCE { im },
+                (_, _, _, _mm) => return Err(()),
             },
             // Store To RAM
             0b0100011 => match I::from_s(with) {
-                (0b000, s1, s2, im) => Ok(SB { s1, s2, im }),
-                (0b001, s1, s2, im) => Ok(SH { s1, s2, im }),
-                (0b010, s1, s2, im) => Ok(SW { s1, s2, im }),
-                (_, _s, _z, _mm) => Err(()),
+                (0b000, s1, s2, im) => SB { s1, s2, im },
+                (0b001, s1, s2, im) => SH { s1, s2, im },
+                (0b010, s1, s2, im) => SW { s1, s2, im },
+                (_, _s, _z, _mm) => return Err(()),
             },
             // Immediate Arithmetic
             0b0010011 => match I::from_i(with) {
-                (d, 0b000, s, im) => Ok(ADDI { d, s, im }),
-                (d, 0b010, s, im) => Ok(SLTI { d, s, im }),
-                (d, 0b011, s, im) => Ok(SLTUI { d, s, im }),
-                (d, 0b100, s, im) => Ok(XORI { d, s, im }),
-                (d, 0b110, s, im) => Ok(ORI { d, s, im }),
-                (d, 0b111, s, im) => Ok(ANDI { d, s, im }),
+                (d, 0b000, s, im) => ADDI { d, s, im },
+                (d, 0b010, s, im) => SLTI { d, s, im },
+                (d, 0b011, s, im) => SLTUI { d, s, im },
+                (d, 0b100, s, im) => XORI { d, s, im },
+                (d, 0b110, s, im) => ORI { d, s, im },
+                (d, 0b111, s, im) => ANDI { d, s, im },
                 _ => match I::from_i7(with) {
-                    (d, 0b001, s, im, 0b0000000) => Ok(SLLI { d, s, im }),
-                    (d, 0b101, s, im, 0b0000000) => Ok(SRLI { d, s, im }),
-                    (d, 0b101, s, im, 0b0100000) => Ok(SRAI { d, s, im }),
-                    (_, _, _, _, _) => Err(()),
+                    (d, 0b001, s, im, 0b0000000) => SLLI { d, s, im },
+                    (d, 0b101, s, im, 0b0000000) => SRLI { d, s, im },
+                    (d, 0b101, s, im, 0b0100000) => SRAI { d, s, im },
+                    (_, _, _, _, _) => return Err(()),
                 },
             },
             // Add Upper Immediate To Program Counter
             0b0010111 => match I::from_u(with) {
-                (d, im) => Ok(AUIPC { d, im }),
+                (d, im) => AUIPC { d, im },
             },
             // Register Arithmetic
             0b0110011 => match I::from_r(with) {
-                (d, 0b000, s1, s2, 0b0000000) => Ok(ADD { d, s1, s2 }),
-                (d, 0b000, s1, s2, 0b0100000) => Ok(SUB { d, s1, s2 }),
-                (d, 0b001, s1, s2, 0b0000000) => Ok(SLL { d, s1, s2 }),
-                (d, 0b010, s1, s2, 0b0000000) => Ok(SLT { d, s1, s2 }),
-                (d, 0b011, s1, s2, 0b0000000) => Ok(SLTU { d, s1, s2 }),
-                (d, 0b100, s1, s2, 0b0000000) => Ok(XOR { d, s1, s2 }),
-                (d, 0b101, s1, s2, 0b0000000) => Ok(SRL { d, s1, s2 }),
-                (d, 0b101, s1, s2, 0b0100000) => Ok(SRA { d, s1, s2 }),
-                (d, 0b110, s1, s2, 0b0000000) => Ok(OR { d, s1, s2 }),
-                (d, 0b111, s1, s2, 0b0000000) => Ok(AND { d, s1, s2 }),
-                (_, _, _s, _z, _) => Err(()),
+                (d, 0b000, s1, s2, 0b0000000) => ADD { d, s1, s2 },
+                (d, 0b000, s1, s2, 0b0100000) => SUB { d, s1, s2 },
+                (d, 0b001, s1, s2, 0b0000000) => SLL { d, s1, s2 },
+                (d, 0b010, s1, s2, 0b0000000) => SLT { d, s1, s2 },
+                (d, 0b011, s1, s2, 0b0000000) => SLTU { d, s1, s2 },
+                (d, 0b100, s1, s2, 0b0000000) => XOR { d, s1, s2 },
+                (d, 0b101, s1, s2, 0b0000000) => SRL { d, s1, s2 },
+                (d, 0b101, s1, s2, 0b0100000) => SRA { d, s1, s2 },
+                (d, 0b110, s1, s2, 0b0000000) => OR { d, s1, s2 },
+                (d, 0b111, s1, s2, 0b0000000) => AND { d, s1, s2 },
+                (_, _, _s, _z, _) => return Err(()),
             },
             // Load upper immediate
             0b0110111 => match I::from_u(with) {
-                (d, im) => Ok(LUI { d, im }),
+                (d, im) => LUI { d, im },
             },
             // Branch on Condition
             0b1100011 => match I::from_s(with) {
-                (0b000, s1, s2, im) => Ok(BEQ { s1, s2, im }),
-                (0b001, s1, s2, im) => Ok(BNE { s1, s2, im }),
-                (0b100, s1, s2, im) => Ok(BLT { s1, s2, im }),
-                (0b101, s1, s2, im) => Ok(BGE { s1, s2, im }),
-                (0b110, s1, s2, im) => Ok(BLTU { s1, s2, im }),
-                (0b111, s1, s2, im) => Ok(BGEU { s1, s2, im }),
-                (_, _s, _z, _mm) => Err(()),
+                (0b000, s1, s2, im) => BEQ { s1, s2, im },
+                (0b001, s1, s2, im) => BNE { s1, s2, im },
+                (0b100, s1, s2, im) => BLT { s1, s2, im },
+                (0b101, s1, s2, im) => BGE { s1, s2, im },
+                (0b110, s1, s2, im) => BLTU { s1, s2, im },
+                (0b111, s1, s2, im) => BGEU { s1, s2, im },
+                (_, _s, _z, _mm) => return Err(()),
             },
             // Jump and link register
             0b1100111 => match I::from_i(with) {
-                (d, 0b000, s, im) => Ok(JALR { d, s, im }),
-                (_d, _, _s, _im) => Err(()),
+                (d, 0b000, s, im) => JALR { d, s, im },
+                (_d, _, _s, _im) => return Err(()),
             },
             // Jump and Link
             0b1101111 => match I::from_u(with) {
-                (d, im) => Ok(JAL { d, im }),
+                (d, im) => JAL { d, im },
             },
             // Transfer Control
             0b1110011 => match I::from_i(with) {
-                (ZERO, 0b000, ZERO, 0b000000000000) => Ok(ECALL {}),
-                (ZERO, 0b000, ZERO, 0b000000000001) => Ok(EBREAK {}),
-                _ => Err(()),
+                (ZERO, 0b000, ZERO, 0b000000000000) => ECALL {},
+                (ZERO, 0b000, ZERO, 0b000000000001) => EBREAK {},
+                _ => return Err(()),
             },
-            _o => Err(()),
-        }
+            _o => return Err(()),
+        })
     }
 }

--- a/asm_riscv/src/lib.rs
+++ b/asm_riscv/src/lib.rs
@@ -520,19 +520,19 @@ impl From<I> for u32 {
     }
 }
 #[derive(Debug, Clone, Copy)]
-///Error types when converting ``u32`` to ``I`
-pub enum ConversionErrorType {
-    ///Unknown funct3 field
+/// Error types when converting `u32` to `I`
+pub enum ConversionError {
+    /// Unknown funct3 field
     UnknownFunct3(u32),
-    ///Unknown funct3 or funct7 field
+    /// Unknown funct3 or funct7 field
     UnknownFunct3Funct7(u32, u32),
-    ///Unknown Environment Control Transfer
+    /// Unknown Environment Control Transfer
     UnknownEnvCtrlTransfer,
-    ///Unknown opcode
+    /// Unknown opcode
     UnknownOpcode(u32),
 }
 impl TryFrom<u32> for I {
-    type Error = ConversionErrorType;
+    type Error = ConversionError;
     // Using match makes it easier to extend code in the future.
     #[allow(clippy::match_single_binding)]
     fn try_from(with: u32) -> Result<Self, Self::Error> {
@@ -545,14 +545,14 @@ impl TryFrom<u32> for I {
                 (d, 0b100, s, im) => LBU { d, s, im },
                 (d, 0b101, s, im) => LHU { d, s, im },
                 (_, funct, _, _mm) => {
-                    return Err(ConversionErrorType::UnknownFunct3(funct))
+                    return Err(ConversionError::UnknownFunct3(funct))
                 }
             },
             // Misc. Memory Instructions
             0b0001111 => match I::from_i(with) {
                 (_, 0b000, _, im) => FENCE { im },
                 (_, funct, _, _mm) => {
-                    return Err(ConversionErrorType::UnknownFunct3(funct))
+                    return Err(ConversionError::UnknownFunct3(funct))
                 }
             },
             // Store To RAM
@@ -561,7 +561,7 @@ impl TryFrom<u32> for I {
                 (0b001, s1, s2, im) => SH { s1, s2, im },
                 (0b010, s1, s2, im) => SW { s1, s2, im },
                 (funct, _s, _z, _mm) => {
-                    return Err(ConversionErrorType::UnknownFunct3(funct))
+                    return Err(ConversionError::UnknownFunct3(funct))
                 }
             },
             // Immediate Arithmetic
@@ -577,7 +577,7 @@ impl TryFrom<u32> for I {
                     (d, 0b101, s, im, 0b0000000) => SRLI { d, s, im },
                     (d, 0b101, s, im, 0b0100000) => SRAI { d, s, im },
                     (_, funct, _, _, _) => {
-                        return Err(ConversionErrorType::UnknownFunct3(funct))
+                        return Err(ConversionError::UnknownFunct3(funct))
                     }
                 },
             },
@@ -598,7 +598,7 @@ impl TryFrom<u32> for I {
                 (d, 0b110, s1, s2, 0b0000000) => OR { d, s1, s2 },
                 (d, 0b111, s1, s2, 0b0000000) => AND { d, s1, s2 },
                 (_, f3, _s, _z, f7) => {
-                    return Err(ConversionErrorType::UnknownFunct3Funct7(
+                    return Err(ConversionError::UnknownFunct3Funct7(
                         f3, f7,
                     ))
                 }
@@ -616,14 +616,14 @@ impl TryFrom<u32> for I {
                 (0b110, s1, s2, im) => BLTU { s1, s2, im },
                 (0b111, s1, s2, im) => BGEU { s1, s2, im },
                 (funct, _s, _z, _mm) => {
-                    return Err(ConversionErrorType::UnknownFunct3(funct))
+                    return Err(ConversionError::UnknownFunct3(funct))
                 }
             },
             // Jump and link register
             0b1100111 => match I::from_i(with) {
                 (d, 0b000, s, im) => JALR { d, s, im },
                 (_d, funct, _s, _im) => {
-                    return Err(ConversionErrorType::UnknownFunct3(funct))
+                    return Err(ConversionError::UnknownFunct3(funct))
                 }
             },
             // Jump and Link
@@ -634,9 +634,9 @@ impl TryFrom<u32> for I {
             0b1110011 => match I::from_i(with) {
                 (ZERO, 0b000, ZERO, 0b000000000000) => ECALL {},
                 (ZERO, 0b000, ZERO, 0b000000000001) => EBREAK {},
-                _ => return Err(ConversionErrorType::UnknownEnvCtrlTransfer),
+                _ => return Err(ConversionError::UnknownEnvCtrlTransfer),
             },
-            o => return Err(ConversionErrorType::UnknownOpcode(o)),
+            o => return Err(ConversionError::UnknownOpcode(o)),
         })
     }
 }

--- a/wari/src/lib.rs
+++ b/wari/src/lib.rs
@@ -37,13 +37,11 @@
 
 /// A WebAssembly Module (decoded by section)
 #[derive(Copy, Clone, Debug)]
-pub struct Module {
-}
+pub struct Module {}
 
 /// Compiles and runs code from WebAssembly Modules
 #[derive(Copy, Clone, Debug)]
-pub struct Runtime {
-}
+pub struct Runtime {}
 
 #[cfg(test)]
 mod tests {

--- a/wari/src/lib.rs
+++ b/wari/src/lib.rs
@@ -37,11 +37,13 @@
 
 /// A WebAssembly Module (decoded by section)
 #[derive(Copy, Clone, Debug)]
-pub struct Module {}
+pub struct Module {
+}
 
 /// Compiles and runs code from WebAssembly Modules
 #[derive(Copy, Clone, Debug)]
-pub struct Runtime {}
+pub struct Runtime {
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I've been using ``asm_riscv`` for a project and the panicking arms on u32 to I conversion have been a thorn in my side.

This returns a Result and lets the user handle a failing conversion instead of panicking.

The Error type could probably use some more info, but i don't really need the sugar for my project so i wanted to get some input before continuing work.